### PR TITLE
Use MeshKit's config provider for threadsafe operations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,10 +4,11 @@ import (
 	"path"
 	"strings"
 
+	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/common"
 	"github.com/layer5io/meshery-adapter-library/config"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
 	"github.com/layer5io/meshery-adapter-library/status"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 	"github.com/layer5io/meshkit/utils"
 	smp "github.com/layer5io/service-mesh-performance/spec"
 )
@@ -24,14 +25,6 @@ var (
 	TraefikMeshOperation = strings.ToLower(smp.ServiceMesh_TRAEFIK_MESH.Enum().String())
 
 	configRootPath = path.Join(utils.GetHome(), ".meshery")
-
-	// Config is the collection of ServerConfig, MeshConfig and ProviderConfig
-	Config = configprovider.Options{
-		ServerConfig:   ServerConfig,
-		MeshSpec:       MeshSpec,
-		ProviderConfig: ProviderConfig,
-		Operations:     Operations,
-	}
 
 	// ServerConfig is the configuration for the gRPC server
 	ServerConfig = map[string]string{
@@ -68,24 +61,55 @@ var (
 )
 
 // New creates a new config instance
-func New(provider string) (config.Handler, error) {
+func New(provider string) (h config.Handler, err error) {
+	opts := configprovider.Options{
+		FilePath: configRootPath,
+		FileName: "traefik",
+		FileType: "yaml",
+	}
 	// Config provider
 	switch provider {
 	case configprovider.ViperKey:
-		return configprovider.NewViper(Config)
+		h, err = configprovider.NewViper(opts)
+		if err != nil {
+			return nil, err
+		}
 	case configprovider.InMemKey:
-		return configprovider.NewInMem(Config)
+		h, err = configprovider.NewInMem(opts)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, ErrEmptyConfig
 	}
 
-	return nil, ErrEmptyConfig
+	// Setup Server config
+	if err := h.SetObject(adapter.ServerKey, ServerConfig); err != nil {
+		return nil, err
+	}
+
+	// setup Mesh config
+	if err := h.SetObject(adapter.MeshSpecKey, MeshSpec); err != nil {
+		return nil, err
+	}
+
+	// setup Operation Config
+	if err := h.SetObject(adapter.OperationsKey, Operations); err != nil {
+		return nil, err
+	}
+
+	return h, nil
 }
 
 // NewKubeconfigBuilder returns a config handler based on the provider
 //
 // Valid prividers are "viper" and "in-mem"
 func NewKubeconfigBuilder(provider string) (config.Handler, error) {
-	opts := configprovider.Options{}
-	opts.ProviderConfig = KubeConfig
+	opts := configprovider.Options{
+		FilePath: configRootPath,
+		FileType: "yaml",
+		FileName: "kubeconfig",
+	}
 
 	// Config provider
 	switch provider {

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 	// "github.com/layer5io/meshkit/tracing"
 	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/api/grpc"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 	"github.com/layer5io/meshery-traefik-mesh/internal/config"
 )
 

--- a/traefik/traefik.go
+++ b/traefik/traefik.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/common"
-	adapterconfig "github.com/layer5io/meshery-adapter-library/config"
+	meshkitCfg "github.com/layer5io/meshkit/config"
 	"github.com/layer5io/meshery-adapter-library/status"
 	internalConfig "github.com/layer5io/meshery-traefik-mesh/internal/config"
 	"github.com/layer5io/meshery-traefik-mesh/traefik/oam"
@@ -26,7 +26,7 @@ type Mesh struct {
 }
 
 // New initializes treafik-mesh handler.
-func New(c adapterconfig.Handler, l logger.Handler, kc adapterconfig.Handler) adapter.Handler {
+func New(c meshkitCfg.Handler, l logger.Handler, kc meshkitCfg.Handler) adapter.Handler {
 	return &Mesh{
 		Adapter: adapter.Adapter{
 			Config:            c,


### PR DESCRIPTION
Signed-off-by: Abhishek-kumar09 <abhimait1909@gmail.com>

**Description**
Replace configprovider coming from meshery-adapter library with meshkit config provider

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
