### PR TITLE
fix typos for traefik-mesh name

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	serviceName = "traefik-mesh-adaptor"
+	serviceName = "traefik-mesh-adapter"
 	version     = "edge"
 	gitsha      = "none"
 )
@@ -52,7 +52,7 @@ func init() {
 	}
 }
 
-// main is the entrypoint of the adaptor
+// main is the entrypoint of the adapter
 func main() {
 	// Initialize Logger instance
 	log, err := logger.New(serviceName, logger.Options{

--- a/traefik/error.go
+++ b/traefik/error.go
@@ -86,7 +86,7 @@ var (
 
 	// ErrNilClient represents the error which is
 	// generated when kubernetes client is nil
-	ErrNilClient = errors.New(ErrNilClientCode, errors.Alert, []string{"kubernetes client not initialized"}, []string{"Kubernetes client is nil"}, []string{"kubernetes client not initialized"}, []string{"Reconnect the adaptor to Meshery server"})
+	ErrNilClient = errors.New(ErrNilClientCode, errors.Alert, []string{"kubernetes client not initialized"}, []string{"Kubernetes client is nil"}, []string{"kubernetes client not initialized"}, []string{"Reconnect the adapter to Meshery server"})
 
 	// ErrParseOAMComponent represents the error which is
 	// generated during the OAM component parsing


### PR DESCRIPTION
Signed-off-by: Pranav Singh <pranavsingh02@hotmail.com>

**Description**
This PR fixes typos in traefik-mesh adapter's name

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
