### PR TITLE
[Cl] Fix minor syntax error in e2etest.yaml

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -106,8 +106,8 @@ jobs:
             service-mesh: traefik-mesh
             service-mesh-version: $(jq '.metadata.service_mesh_version' data.json)
             tests:
-              traefik-mesh-controller: $(jq '.pods_status."traefik-mesh-controller' data.json)
-              traefik-mesh-proxy: $(jq '.pods_status."traefik-mesh-proxy' data.json)
+              traefik-mesh-controller: $(jq '.pods_status."traefik-mesh-controller"' data.json)
+              traefik-mesh-proxy: $(jq '.pods_status."traefik-mesh-proxy"' data.json)
               grafana-core:  $(jq '.pods_status."grafana-core"' data.json)
               jaeger: $(jq '.pods_status."jaeger"' data.json)
               prometheus-core: $(jq '.pods_status."prometheus-core"' data.json) 


### PR DESCRIPTION
Signed-off-by: Pranav Singh <pranavsingh02@hotmail.com>

**Description**
This PR fixes minor syntax errors for the missing `"` in the e2etest.yaml

I realized this after seeing the capability matrix folder for traefik-mesh adapter on meshery repo.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
