### PR TITLE
Use Git walker to avoid using GitHub API

### DIFF
--- a/build/config.go
+++ b/build/config.go
@@ -71,14 +71,14 @@ func init() {
 	DefaultGenerationMethod = adapter.Manifests
 
 	//Get all the crd names
-	w := walker.NewGithub()
+	w := walker.NewGit()
 	err := w.Owner("traefik").
 		Repo("mesh-helm-chart").
 		Branch("master").
 		Root("mesh/crds/**").
-		RegisterFileInterceptor(func(gca walker.GithubContentAPI) error {
-			if gca.Content != "" {
-				CRDNames = append(CRDNames, gca.Name)
+		RegisterFileInterceptor(func(file walker.File) error {
+			if file.Content != "" {
+				CRDNames = append(CRDNames, file.Name)
 			}
 			return nil
 		}).Walk()


### PR DESCRIPTION
Signed-off-by: Ruturaj Mohite <mohite.ruturaj15@gmail.com>

**Description**
Replaces GitHub walker with Git walker to avoid using the GitHub API which causes rate limit issues

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
