### PR TITLE
Add no-duplicate-categories to prevent duplicate PR entries in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: "Meshery Adapter for Traefik Mesh v$NEXT_PATCH_VERSION"
 tag-template: "v$NEXT_PATCH_VERSION"
+no-duplicate-categories: true
 categories:
   - title: "🚀 Features"
     labels:
@@ -16,7 +17,8 @@ categories:
       - "area/ci"
       - "area/tests"
   - title: 📖 Documentation
-    label: area/docs
+    labels:
+      - area/docs
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 template: |
   ## What's New


### PR DESCRIPTION
- Added 'no-duplicate-categories: true' to prevent PRs from appearing in multiple categories

- Standardized label format to use 'labels:' array format for consistency

When a PR has multiple labels matching different categories, it will now appear only in the first matching category.
