### PR TITLE
ci: checkout Meshery master for docs publishing

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -80,6 +80,7 @@ jobs:
         - uses: actions/checkout@v3
           with:
             repository: meshery/meshery 
+            ref: master
             token: ${{ secrets.GH_ACCESS_TOKEN }}   
         - name: DownloadJSON
           uses: actions/download-artifact@v2


### PR DESCRIPTION
## Summary

- explicitly checkout the Meshery master branch in the compatibility-doc publishing job
- prevent the auto-commit step from running on a detached HEAD

## Validation

- parsed the workflow as YAML
- ran git diff --check

Fixes #340

Signed-off-by: Kauhsik Raj <algorithmunloack@gmail.com>