### PR TITLE
docs: document current Go toolchain requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ alt="Traefik Mesh - Simpler Service Mesh" align="left" /></a>
 <br /><br />
 </p>
 
+## Development
+
+Building this adapter requires Go 1.26.4 or newer. The required version is
+kept in sync across `go.mod`, the Docker builder image, and the Makefile's
+dependency check.
+
+Run the local validation suite with:
+
+```sh
+make test
+```
+
 <p style="clear:both;">
 <h2><a name="contributing"></a><a name="community"></a> <a href="http://slack.meshery.io">Community</a> and <a href="https://docs.meshery.io/project/contributing">Contributing</a></h2>
 Our projects are community-built and welcome collaboration. 👍 Be sure to see the <a href="https://docs.meshery.io/project/community#getting-involved-in-the-community">Meshery Community Welcome Guide</a> for a tour of resources available to you and jump into our <a href="http://slack.meshery.io">Slack</a>! Contributors are expected to adhere to the <a href="https://github.com/cncf/foundation/blob/master/code-of-conduct.md">CNCF Code of Conduct</a>.


### PR DESCRIPTION
## Summary

- document Go 1.26.4 as the current minimum development toolchain
- provide the repository test command for contributors
- clarify that go.mod, Docker, and Makefile already share the same version

## Context

Issue #338 requested Go 1.25. The repository has since advanced to Go 1.26.4, so this PR documents the completed and superseding baseline instead of downgrading it.

## Validation

- verified the Go version matches across go.mod, Dockerfile, and build/Makefile.core.mk
- ran git diff --check

Related to #338

Signed-off-by: Kauhsik Raj <algorithmunloack@gmail.com>