### PR TITLE
fix: constrain Traefik release requests

### DIFF
--- a/internal/config/releases.go
+++ b/internal/config/releases.go
@@ -7,9 +7,15 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
+	"time"
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
 )
+
+const traefikReleasesURL = "https://api.github.com/repos/traefik/mesh/releases"
+
+var releaseHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
 // Release is used to save the release informations
 type Release struct {
@@ -64,13 +70,22 @@ func getLatestReleaseNames(limit int) ([]adapter.Version, error) {
 
 // GetLatestReleases fetches the latest releases from the traefik mesh repository
 func GetLatestReleases(releases uint) ([]*Release, error) {
-	releaseAPIURL := "https://api.github.com/repos/traefik/mesh/releases?per_page=" + fmt.Sprint(releases)
-	// We need a variable url here hence using nosec
-	// #nosec
-	resp, err := http.Get(releaseAPIURL)
+	req, err := http.NewRequest(http.MethodGet, traefikReleasesURL, nil)
 	if err != nil {
 		return []*Release{}, ErrGetLatestReleases(err)
 	}
+
+	query := req.URL.Query()
+	query.Set("per_page", strconv.FormatUint(uint64(releases), 10))
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := releaseHTTPClient.Do(req)
+	if err != nil {
+		return []*Release{}, ErrGetLatestReleases(err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return []*Release{}, ErrGetLatestReleases(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
@@ -84,10 +99,6 @@ func GetLatestReleases(releases uint) ([]*Release, error) {
 	var releaseList []*Release
 
 	if err = json.Unmarshal(body, &releaseList); err != nil {
-		return []*Release{}, ErrGetLatestReleases(err)
-	}
-
-	if err = resp.Body.Close(); err != nil {
 		return []*Release{}, ErrGetLatestReleases(err)
 	}
 

--- a/internal/config/releases_test.go
+++ b/internal/config/releases_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestGetLatestReleasesUsesTrustedEndpoint(t *testing.T) {
+	originalClient := releaseHTTPClient
+	t.Cleanup(func() { releaseHTTPClient = originalClient })
+
+	releaseHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Scheme + "://" + req.URL.Host + req.URL.Path; got != traefikReleasesURL {
+			t.Fatalf("unexpected release endpoint: %s", got)
+		}
+		if got := req.URL.Query().Get("per_page"); got != "3" {
+			t.Fatalf("unexpected per_page query: %s", got)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":1,"name":"v1.4.8"}]`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	releases, err := GetLatestReleases(3)
+	if err != nil {
+		t.Fatalf("GetLatestReleases() error = %v", err)
+	}
+	if len(releases) != 1 || releases[0].Name != "v1.4.8" {
+		t.Fatalf("unexpected releases: %#v", releases)
+	}
+}
+
+func TestGetLatestReleasesRejectsUnexpectedStatus(t *testing.T) {
+	originalClient := releaseHTTPClient
+	t.Cleanup(func() { releaseHTTPClient = originalClient })
+
+	releaseHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader("rate limited")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	if _, err := GetLatestReleases(1); err == nil {
+		t.Fatal("GetLatestReleases() expected an error for a non-200 response")
+	}
+}


### PR DESCRIPTION
## Summary

- build release requests from a constant trusted GitHub API endpoint
- encode the release count as a query parameter
- replace the unbounded default HTTP client with a 15-second timeout
- close response bodies on every return path
- add tests for endpoint construction and non-200 responses

## Validation

- go test ./internal/config
- go test ./...
- go vet ./...
- git diff --check

Fixes #138

Signed-off-by: Kauhsik Raj <algorithmunloack@gmail.com>