### PR TITLE
ci: pin mesheryctl-based adapter E2E workflow

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -46,7 +46,8 @@ jobs:
 
   TestTraefik:
     needs: SetPatterfile
-    uses: meshery/meshery/.github/workflows/test_adaptersv2.yaml@master
+    # This revision installs Meshery through mesheryctl before testing the adapter.
+    uses: meshery/meshery/.github/workflows/test_adaptersv2.yaml@d04a78869262be3778783d552bdf84a65a5ca2bb
     with:
       expected_resources: grafana-core,jaeger,prometheus-core,traefik-mesh-controller,traefik-mesh-proxy
       expected_resources_types: pod,pod,pod,pod,pod


### PR DESCRIPTION
## Summary

- pin the adapter E2E job to a verified Meshery workflow revision
- guarantee that the selected workflow starts Meshery through mesheryctl
- avoid behavior changing underneath this adapter when Meshery master advances

## Validation

Verified the pinned workflow contains the Meshery startup and design-apply mesheryctl steps. Also parsed the local workflow as YAML and ran git diff --check.

Fixes #178

Signed-off-by: Kauhsik Raj <algorithmunloack@gmail.com>