### PR TITLE
test: deploy Bookinfo through the adapter pattern

### DIFF
--- a/.github/install/deploy.yaml
+++ b/.github/install/deploy.yaml
@@ -6,4 +6,182 @@ services:
     apiVersion: core.meshmodel.dev/v1alpha1
     namespace: traefik
     version:  #will be inserted dynamically
-
+  bookinfo-details:
+    type: ServiceAccount.K8s
+    namespace: default
+    labels:
+      account: details
+  details:
+    type: Service.K8s
+    namespace: default
+    labels:
+      app: details
+      service: details
+    settings:
+      spec:
+        ports:
+          - name: http
+            port: 9080
+        selector:
+          app: details
+  details-v1:
+    type: Deployment.K8s
+    namespace: default
+    labels:
+      app: details
+      version: v1
+    settings:
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: details
+            version: v1
+        template:
+          metadata:
+            labels:
+              app: details
+              version: v1
+          spec:
+            serviceAccountName: bookinfo-details
+            containers:
+              - name: details
+                image: docker.io/istio/examples-bookinfo-details-v1:1.16.4
+                imagePullPolicy: IfNotPresent
+                ports:
+                  - containerPort: 9080
+  bookinfo-ratings:
+    type: ServiceAccount.K8s
+    namespace: default
+    labels:
+      account: ratings
+  ratings:
+    type: Service.K8s
+    namespace: default
+    labels:
+      app: ratings
+      service: ratings
+    settings:
+      spec:
+        ports:
+          - name: http
+            port: 9080
+        selector:
+          app: ratings
+  ratings-v1:
+    type: Deployment.K8s
+    namespace: default
+    labels:
+      app: ratings
+      version: v1
+    settings:
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: ratings
+            version: v1
+        template:
+          metadata:
+            labels:
+              app: ratings
+              version: v1
+          spec:
+            serviceAccountName: bookinfo-ratings
+            containers:
+              - name: ratings
+                image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.4
+                imagePullPolicy: IfNotPresent
+                ports:
+                  - containerPort: 9080
+  bookinfo-reviews:
+    type: ServiceAccount.K8s
+    namespace: default
+    labels:
+      account: reviews
+  reviews:
+    type: Service.K8s
+    namespace: default
+    labels:
+      app: reviews
+      service: reviews
+    settings:
+      spec:
+        ports:
+          - name: http
+            port: 9080
+        selector:
+          app: reviews
+  reviews-v1:
+    type: Deployment.K8s
+    namespace: default
+    labels:
+      app: reviews
+      version: v1
+    settings:
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: reviews
+            version: v1
+        template:
+          metadata:
+            labels:
+              app: reviews
+              version: v1
+          spec:
+            serviceAccountName: bookinfo-reviews
+            containers:
+              - name: reviews
+                image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.4
+                imagePullPolicy: IfNotPresent
+                env:
+                  - name: LOG_DIR
+                    value: /tmp/logs
+                ports:
+                  - containerPort: 9080
+  bookinfo-productpage:
+    type: ServiceAccount.K8s
+    namespace: default
+    labels:
+      account: productpage
+  productpage:
+    type: Service.K8s
+    namespace: default
+    labels:
+      app: productpage
+      service: productpage
+    settings:
+      spec:
+        ports:
+          - name: http
+            port: 9080
+        selector:
+          app: productpage
+  productpage-v1:
+    type: Deployment.K8s
+    namespace: default
+    labels:
+      app: productpage
+      version: v1
+    settings:
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: productpage
+            version: v1
+        template:
+          metadata:
+            labels:
+              app: productpage
+              version: v1
+          spec:
+            serviceAccountName: bookinfo-productpage
+            containers:
+              - name: productpage
+                image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.4
+                imagePullPolicy: IfNotPresent
+                ports:
+                  - containerPort: 9080

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -12,21 +12,24 @@ on:
   release:
     types: [published]
 jobs:
-  SetPatterfile:
+  SetPatternfile:
     runs-on: ubuntu-latest
     outputs:
       sm_version: ${{ steps.gettag.outputs.release }}
-      adapter_version:  ${{ env.version }}
+      adapter_version: ${{ steps.adapter-version.outputs.version }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
       - name: Get version of adapter
+        id: adapter-version
         run: |
             if [ ${{ github.event_name }} == "release" ];then
-                echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+                version=${GITHUB_REF/refs\/tags\//}
             else 
-                echo "version=edge" >> $GITHUB_ENV
+                version=edge
             fi
+            echo "version=$version" >> $GITHUB_ENV
+            echo "version=$version" >> $GITHUB_OUTPUT
       - name: Get latest release tag
         id: gettag
         uses: pozetroninc/github-action-get-latest-release@master
@@ -45,12 +48,12 @@ jobs:
           path: ./.github/install/deploy.yaml 
 
   TestTraefik:
-    needs: SetPatterfile
+    needs: SetPatternfile
     uses: meshery/meshery/.github/workflows/test_adaptersv2.yaml@master
     with:
-      expected_resources: grafana-core,jaeger,prometheus-core,traefik-mesh-controller,traefik-mesh-proxy
-      expected_resources_types: pod,pod,pod,pod,pod
-      expected_resources_namespaces: traefik,traefik,traefik,traefik,traefik
+      expected_resources: grafana-core,jaeger,prometheus-core,traefik-mesh-controller,traefik-mesh-proxy,details-v1,ratings-v1,reviews-v1,productpage-v1,details,ratings,reviews,productpage
+      expected_resources_types: pod,pod,pod,pod,pod,deployment,deployment,deployment,deployment,service,service,service,service
+      expected_resources_namespaces: traefik,traefik,traefik,traefik,traefik,default,default,default,default,default,default,default,default
       deployment_url: https://raw.githubusercontent.com/meshery/meshery/master/install/deployment_yamls/k8s/meshery-traefik-mesh-deployment.yaml
       service_url: https://raw.githubusercontent.com/meshery/meshery/master/install/deployment_yamls/k8s/meshery-traefik-mesh-service.yaml
       adapter_name: traefik


### PR DESCRIPTION
## Summary

- extend the adapter design fixture with a minimal Bookinfo application
- assert the Bookinfo deployments and services alongside Traefik Mesh resources
- fix the SetPatternfile job name and expose the adapter version as a proper step output

## Validation

- parsed the design and workflow as YAML
- verified resource, type, and namespace assertion counts match
- ran go test ./...
- ran go vet ./...
- ran git diff --check

The historical fixture linked from #174 was deleted and installed Istio. This PR preserves the intended pattern-based application test while adapting it to the Traefik Mesh adapter.

Fixes #174

Signed-off-by: Kauhsik Raj <algorithmunloack@gmail.com>